### PR TITLE
fix: plugin config mismatch

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,6 +14,12 @@ export const emailTemplatePlugin =
       config.collections = []
     }
 
+    const isEnabled = pluginOptions.enabled ?? true
+
+    if (!isEnabled) {
+      return config
+    }
+
     const imageCollectionSlug = pluginOptions.imageCollectionSlug || 'media'
     const disableStyle =
       pluginOptions.disableStyle === undefined ? false : pluginOptions.disableStyle
@@ -75,10 +81,6 @@ export const emailTemplatePlugin =
     })
 
     config.collections.push(emailTemplates)
-
-    if (pluginOptions.disabled) {
-      return config
-    }
 
     if (!config.endpoints) {
       config.endpoints = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,7 +177,12 @@ export type FallbackFont =
 export type FontFormat = 'woff' | 'woff2' | 'truetype' | 'opentype' | 'embedded-opentype' | 'svg'
 
 export type PluginOptions = {
-  disabled?: boolean
+  /**
+   * Enable the plugin features.
+   * Defaults to true. Set to false to disable the plugin.
+   * @default true
+   */
+  enabled?: boolean
   /**
    * The collection slug to use for the image field.
    * @default 'media'


### PR DESCRIPTION
close #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Configuration option renamed: use enabled instead of disabled.
  * Migration note: if you previously used disabled: false to keep the plugin active, set enabled: true.

* **Behavior Change**
  * Plugin is enabled by default unless enabled is explicitly set to false.

* **Chores**
  * Activation check updated and applied earlier in initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->