### PR TITLE
Add local api for rendering templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,14 @@ import { renderEmailTemplate } from "payload-email-template"
 //   ...
 // })
 
-const html = renderEmailTemplate({
+const html = await renderEmailTemplate({
   data: emailTemplate,
   locale: 'en',
   format: 'html',
   macroContext: {
-    companyName: 'Acme Corporation'
-    // ...
+    variables: { ... },
+    functions: { ... },
+    config: { ... }
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,34 @@ Then you can send it via your email provider.
 
 ---
 
+## ⚙ Local Api
+
+### Generate Email Template
+
+It's also possible to render the email template by calling `renderEmailTemplate` directly in the back-end, skipping the http request in that case.
+
+```js
+import { renderEmailTemplate } from "payload-email-template"
+
+// const emailTemplate = await req.payload.find({
+//   collection: 'email-templates',
+//   ...
+// })
+
+const html = renderEmailTemplate({
+  data: emailTemplate,
+  locale: 'en',
+  format: 'html',
+  macroContext: {
+    companyName: 'Acme Corporation'
+    // ...
+  }
+})
+
+```
+
+---
+
 ## 🔧 Macros
 
 The plugin supports powerful dynamic content through macros that can be used in email subjects, headings, and text blocks.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { emailTemplatePlugin } from './plugin.js'
+export { renderEmailTemplate } from './utils/renderEmailTemplate.js'


### PR DESCRIPTION
I'm implementing templates for `form-builder` plugin. Rendering them from a hook and it seems silly I have to call myself with a POST request. 
So I suggest adding a local API.
Just calling `renderEmailTemplate` seems fine - as long as you pass EmailTemplate in `data`. Having types for that would be nice but I'm honestly not sure if it's even possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local, server-side API to render email templates without HTTP requests. Supports rendering to HTML, locale and format options, and passing contextual data (e.g., company name) for customized output.

* **Documentation**
  * README updated with a new section showing how to use the local rendering API, including setup, example usage, and guidance on data, locale, format, and macro context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->